### PR TITLE
Add context parameter on all send async methods 

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -22,3 +22,6 @@ jobs:
       - name: Build SDK project
         run: go build
         working-directory: ${{ env.relativePath }}
+      - name: Test project
+        run: go test
+        working-directory: ${{ env.relativePath }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.7.0] - 2022-08-24
 
-- Adds context param in send async methods
-
 ### Added
 
-- Adds a chaos handler optional middleware for tests
+- Adds context param in send async methods
 
 ## [0.6.2] - 2022-08-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+## [0.7.0] - 2022-08-24
+
+- Adds context param in send async methods
+
+### Added
+
+- Adds a chaos handler optional middleware for tests
+
 ## [0.6.2] - 2022-08-30
 
 ### Added

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/microsoft/kiota-http-go
 go 1.18
 
 require (
-	github.com/microsoft/kiota-abstractions-go v0.8.2
+	github.com/microsoft/kiota-abstractions-go v0.9.0
 	github.com/stretchr/testify v1.8.0
 )
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/microsoft/kiota-http-go
 go 1.18
 
 require (
-	github.com/microsoft/kiota-abstractions-go v0.9.0
+	github.com/microsoft/kiota-abstractions-go v0.9.1
 	github.com/stretchr/testify v1.8.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -18,6 +18,5 @@ github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zI
 github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT040gmv5BQTMR2HP4=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/go.sum
+++ b/go.sum
@@ -5,8 +5,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/microsoft/kiota-abstractions-go v0.8.2 h1:KxHr72YwlntvVgF0C+8CtNmNQajtIq7fedq2N0+74Uk=
-github.com/microsoft/kiota-abstractions-go v0.8.2/go.mod h1:i1wK2rdsLGSjgpnpLHjC60nEa/UdCVS6ulCh1Q+1COw=
+github.com/microsoft/kiota-abstractions-go v0.9.0 h1:HqqC/vFGMO1XHQmkicVkMUGdQc2poLr3ynijQ/2PrTk=
+github.com/microsoft/kiota-abstractions-go v0.9.0/go.mod h1:i1wK2rdsLGSjgpnpLHjC60nEa/UdCVS6ulCh1Q+1COw=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
@@ -18,5 +18,6 @@ github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zI
 github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT040gmv5BQTMR2HP4=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/go.sum
+++ b/go.sum
@@ -5,8 +5,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/microsoft/kiota-abstractions-go v0.9.0 h1:HqqC/vFGMO1XHQmkicVkMUGdQc2poLr3ynijQ/2PrTk=
-github.com/microsoft/kiota-abstractions-go v0.9.0/go.mod h1:i1wK2rdsLGSjgpnpLHjC60nEa/UdCVS6ulCh1Q+1COw=
+github.com/microsoft/kiota-abstractions-go v0.9.1 h1:22k/yIJVChq8TZyWT/X6RRUiVw1mLe44w60aYeukzKQ=
+github.com/microsoft/kiota-abstractions-go v0.9.1/go.mod h1:i1wK2rdsLGSjgpnpLHjC60nEa/UdCVS6ulCh1Q+1COw=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
@@ -18,5 +18,6 @@ github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zI
 github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT040gmv5BQTMR2HP4=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/nethttp_request_adapter.go
+++ b/nethttp_request_adapter.go
@@ -200,8 +200,10 @@ func (a *NetHttpRequestAdapter) SendAsync(ctx context.Context, requestInfo *abs.
 	if err != nil {
 		return nil, err
 	}
-	if requestInfo.ResponseHandler != nil {
-		result, err := requestInfo.ResponseHandler(response, errorMappings)
+
+	responseHandler := getResponseHandler(ctx)
+	if responseHandler != nil {
+		result, err := responseHandler(response, errorMappings)
 		if err != nil {
 			return nil, err
 		}
@@ -238,8 +240,10 @@ func (a *NetHttpRequestAdapter) SendEnumAsync(ctx context.Context, requestInfo *
 	if err != nil {
 		return nil, err
 	}
-	if requestInfo.ResponseHandler != nil {
-		result, err := requestInfo.ResponseHandler(response, errorMappings)
+
+	responseHandler := getResponseHandler(ctx)
+	if responseHandler != nil {
+		result, err := responseHandler(response, errorMappings)
 		if err != nil {
 			return nil, err
 		}
@@ -276,8 +280,10 @@ func (a *NetHttpRequestAdapter) SendCollectionAsync(ctx context.Context, request
 	if err != nil {
 		return nil, err
 	}
-	if requestInfo.ResponseHandler != nil {
-		result, err := requestInfo.ResponseHandler(response, errorMappings)
+
+	responseHandler := getResponseHandler(ctx)
+	if responseHandler != nil {
+		result, err := responseHandler(response, errorMappings)
 		if err != nil {
 			return nil, err
 		}
@@ -314,8 +320,10 @@ func (a *NetHttpRequestAdapter) SendEnumCollectionAsync(ctx context.Context, req
 	if err != nil {
 		return nil, err
 	}
-	if requestInfo.ResponseHandler != nil {
-		result, err := requestInfo.ResponseHandler(response, errorMappings)
+
+	responseHandler := getResponseHandler(ctx)
+	if responseHandler != nil {
+		result, err := responseHandler(response, errorMappings)
 		if err != nil {
 			return nil, err
 		}
@@ -343,6 +351,14 @@ func (a *NetHttpRequestAdapter) SendEnumCollectionAsync(ctx context.Context, req
 	}
 }
 
+func getResponseHandler(ctx context.Context) abs.ResponseHandler {
+	var optionKey = ctx.Value(abs.ResponseHandlerOptionKey)
+	if optionKey != nil {
+		return ctx.Value(abs.ResponseHandlerOptionKey).(abs.RequestHandlerOption).GetResponseHandler()
+	}
+	return nil
+}
+
 // SendPrimitiveAsync executes the HTTP request specified by the given RequestInformation and returns the deserialized primitive response model.
 func (a *NetHttpRequestAdapter) SendPrimitiveAsync(ctx context.Context, requestInfo *abs.RequestInformation, typeName string, errorMappings abs.ErrorMappings) (interface{}, error) {
 	if requestInfo == nil {
@@ -352,8 +368,10 @@ func (a *NetHttpRequestAdapter) SendPrimitiveAsync(ctx context.Context, requestI
 	if err != nil {
 		return nil, err
 	}
-	if requestInfo.ResponseHandler != nil {
-		result, err := requestInfo.ResponseHandler(response, errorMappings)
+
+	responseHandler := getResponseHandler(ctx)
+	if responseHandler != nil {
+		result, err := responseHandler(response, errorMappings)
 		if err != nil {
 			return nil, err
 		}
@@ -411,8 +429,10 @@ func (a *NetHttpRequestAdapter) SendPrimitiveCollectionAsync(ctx context.Context
 	if err != nil {
 		return nil, err
 	}
-	if requestInfo.ResponseHandler != nil {
-		result, err := requestInfo.ResponseHandler(response, errorMappings)
+
+	responseHandler := getResponseHandler(ctx)
+	if responseHandler != nil {
+		result, err := responseHandler(response, errorMappings)
 		if err != nil {
 			return nil, err
 		}
@@ -448,8 +468,10 @@ func (a *NetHttpRequestAdapter) SendNoContentAsync(ctx context.Context, requestI
 	if err != nil {
 		return err
 	}
-	if requestInfo.ResponseHandler != nil {
-		_, err := requestInfo.ResponseHandler(response, errorMappings)
+
+	responseHandler := getResponseHandler(ctx)
+	if responseHandler != nil {
+		_, err := responseHandler(response, errorMappings)
 		return err
 	} else if response != nil {
 		defer a.purge(response)

--- a/nethttp_request_adapter.go
+++ b/nethttp_request_adapter.go
@@ -147,16 +147,22 @@ func (a *NetHttpRequestAdapter) getResponsePrimaryContentType(response *nethttp.
 	splat := strings.Split(rawType, ";")
 	return strings.ToLower(splat[0])
 }
+
 func (a *NetHttpRequestAdapter) setBaseUrlForRequestInformation(requestInfo *abs.RequestInformation) {
 	requestInfo.PathParameters["baseurl"] = a.GetBaseUrl()
 }
 
+<<<<<<< HEAD
 const requestTimeOutInSeconds = 100
 
 func (a *NetHttpRequestAdapter) getRequestFromRequestInformation(ctx context.Context, requestInfo *abs.RequestInformation) (*nethttp.Request, error) {
 	uri, err := requestInfo.GetUri()
 	if err != nil {
 		return nil, err
+	}
+
+	if ctx == nil {
+		ctx = context.Background()
 	}
 
 	// add deadline of not set
@@ -183,7 +189,7 @@ func (a *NetHttpRequestAdapter) getRequestFromRequestInformation(ctx context.Con
 		}
 	}
 	for _, value := range requestInfo.GetRequestOptions() {
-		request = request.WithContext(context.WithValue(ctx, value.GetKey(), value))
+		request = request.WithContext(context.WithValue(ctx.Context(), value.GetKey(), value))
 	}
 	return request, nil
 }

--- a/nethttp_request_adapter.go
+++ b/nethttp_request_adapter.go
@@ -163,7 +163,7 @@ func (a *NetHttpRequestAdapter) getRequestFromRequestInformation(ctx context.Con
 		return nil, err
 	}
 
-	// add deadline of not set
+	// set deadline if not set in receiving context
 	if _, deadlineSet := ctx.Deadline(); !deadlineSet {
 		ctxTimed, _ := context.WithTimeout(ctx, time.Second*requestTimeOutInSeconds)
 		ctx = ctxTimed

--- a/nethttp_request_adapter.go
+++ b/nethttp_request_adapter.go
@@ -192,7 +192,7 @@ func (a *NetHttpRequestAdapter) getRequestFromRequestInformation(ctx context.Con
 }
 
 // SendAsync executes the HTTP request specified by the given RequestInformation and returns the deserialized response model.
-func (a *NetHttpRequestAdapter) SendAsync(ctx context.Context, requestInfo *abs.RequestInformation, constructor absser.ParsableFactory, responseHandler abs.ResponseHandler, errorMappings abs.ErrorMappings) (absser.Parsable, error) {
+func (a *NetHttpRequestAdapter) SendAsync(ctx context.Context, requestInfo *abs.RequestInformation, constructor absser.ParsableFactory, errorMappings abs.ErrorMappings) (absser.Parsable, error) {
 	if requestInfo == nil {
 		return nil, errors.New("requestInfo cannot be nil")
 	}
@@ -200,8 +200,8 @@ func (a *NetHttpRequestAdapter) SendAsync(ctx context.Context, requestInfo *abs.
 	if err != nil {
 		return nil, err
 	}
-	if responseHandler != nil {
-		result, err := responseHandler(response, errorMappings)
+	if requestInfo.ResponseHandler != nil {
+		result, err := requestInfo.ResponseHandler(response, errorMappings)
 		if err != nil {
 			return nil, err
 		}
@@ -230,7 +230,7 @@ func (a *NetHttpRequestAdapter) SendAsync(ctx context.Context, requestInfo *abs.
 }
 
 // SendEnumAsync executes the HTTP request specified by the given RequestInformation and returns the deserialized response model.
-func (a *NetHttpRequestAdapter) SendEnumAsync(ctx context.Context, requestInfo *abs.RequestInformation, parser absser.EnumFactory, responseHandler abs.ResponseHandler, errorMappings abs.ErrorMappings) (interface{}, error) {
+func (a *NetHttpRequestAdapter) SendEnumAsync(ctx context.Context, requestInfo *abs.RequestInformation, parser absser.EnumFactory, errorMappings abs.ErrorMappings) (interface{}, error) {
 	if requestInfo == nil {
 		return nil, errors.New("requestInfo cannot be nil")
 	}
@@ -238,8 +238,8 @@ func (a *NetHttpRequestAdapter) SendEnumAsync(ctx context.Context, requestInfo *
 	if err != nil {
 		return nil, err
 	}
-	if responseHandler != nil {
-		result, err := responseHandler(response, errorMappings)
+	if requestInfo.ResponseHandler != nil {
+		result, err := requestInfo.ResponseHandler(response, errorMappings)
 		if err != nil {
 			return nil, err
 		}
@@ -268,7 +268,7 @@ func (a *NetHttpRequestAdapter) SendEnumAsync(ctx context.Context, requestInfo *
 }
 
 // SendCollectionAsync executes the HTTP request specified by the given RequestInformation and returns the deserialized response model collection.
-func (a *NetHttpRequestAdapter) SendCollectionAsync(ctx context.Context, requestInfo *abs.RequestInformation, constructor absser.ParsableFactory, responseHandler abs.ResponseHandler, errorMappings abs.ErrorMappings) ([]absser.Parsable, error) {
+func (a *NetHttpRequestAdapter) SendCollectionAsync(ctx context.Context, requestInfo *abs.RequestInformation, constructor absser.ParsableFactory, errorMappings abs.ErrorMappings) ([]absser.Parsable, error) {
 	if requestInfo == nil {
 		return nil, errors.New("requestInfo cannot be nil")
 	}
@@ -276,8 +276,8 @@ func (a *NetHttpRequestAdapter) SendCollectionAsync(ctx context.Context, request
 	if err != nil {
 		return nil, err
 	}
-	if responseHandler != nil {
-		result, err := responseHandler(response, errorMappings)
+	if requestInfo.ResponseHandler != nil {
+		result, err := requestInfo.ResponseHandler(response, errorMappings)
 		if err != nil {
 			return nil, err
 		}
@@ -306,7 +306,7 @@ func (a *NetHttpRequestAdapter) SendCollectionAsync(ctx context.Context, request
 }
 
 // SendEnumCollectionAsync executes the HTTP request specified by the given RequestInformation and returns the deserialized response model collection.
-func (a *NetHttpRequestAdapter) SendEnumCollectionAsync(ctx context.Context, requestInfo *abs.RequestInformation, parser absser.EnumFactory, responseHandler abs.ResponseHandler, errorMappings abs.ErrorMappings) ([]interface{}, error) {
+func (a *NetHttpRequestAdapter) SendEnumCollectionAsync(ctx context.Context, requestInfo *abs.RequestInformation, parser absser.EnumFactory, errorMappings abs.ErrorMappings) ([]interface{}, error) {
 	if requestInfo == nil {
 		return nil, errors.New("requestInfo cannot be nil")
 	}
@@ -314,8 +314,8 @@ func (a *NetHttpRequestAdapter) SendEnumCollectionAsync(ctx context.Context, req
 	if err != nil {
 		return nil, err
 	}
-	if responseHandler != nil {
-		result, err := responseHandler(response, errorMappings)
+	if requestInfo.ResponseHandler != nil {
+		result, err := requestInfo.ResponseHandler(response, errorMappings)
 		if err != nil {
 			return nil, err
 		}
@@ -344,7 +344,7 @@ func (a *NetHttpRequestAdapter) SendEnumCollectionAsync(ctx context.Context, req
 }
 
 // SendPrimitiveAsync executes the HTTP request specified by the given RequestInformation and returns the deserialized primitive response model.
-func (a *NetHttpRequestAdapter) SendPrimitiveAsync(ctx context.Context, requestInfo *abs.RequestInformation, typeName string, responseHandler abs.ResponseHandler, errorMappings abs.ErrorMappings) (interface{}, error) {
+func (a *NetHttpRequestAdapter) SendPrimitiveAsync(ctx context.Context, requestInfo *abs.RequestInformation, typeName string, errorMappings abs.ErrorMappings) (interface{}, error) {
 	if requestInfo == nil {
 		return nil, errors.New("requestInfo cannot be nil")
 	}
@@ -352,8 +352,8 @@ func (a *NetHttpRequestAdapter) SendPrimitiveAsync(ctx context.Context, requestI
 	if err != nil {
 		return nil, err
 	}
-	if responseHandler != nil {
-		result, err := responseHandler(response, errorMappings)
+	if requestInfo.ResponseHandler != nil {
+		result, err := requestInfo.ResponseHandler(response, errorMappings)
 		if err != nil {
 			return nil, err
 		}
@@ -403,7 +403,7 @@ func (a *NetHttpRequestAdapter) SendPrimitiveAsync(ctx context.Context, requestI
 }
 
 // SendPrimitiveCollectionAsync executes the HTTP request specified by the given RequestInformation and returns the deserialized primitive response model collection.
-func (a *NetHttpRequestAdapter) SendPrimitiveCollectionAsync(ctx context.Context, requestInfo *abs.RequestInformation, typeName string, responseHandler abs.ResponseHandler, errorMappings abs.ErrorMappings) ([]interface{}, error) {
+func (a *NetHttpRequestAdapter) SendPrimitiveCollectionAsync(ctx context.Context, requestInfo *abs.RequestInformation, typeName string, errorMappings abs.ErrorMappings) ([]interface{}, error) {
 	if requestInfo == nil {
 		return nil, errors.New("requestInfo cannot be nil")
 	}
@@ -411,8 +411,8 @@ func (a *NetHttpRequestAdapter) SendPrimitiveCollectionAsync(ctx context.Context
 	if err != nil {
 		return nil, err
 	}
-	if responseHandler != nil {
-		result, err := responseHandler(response, errorMappings)
+	if requestInfo.ResponseHandler != nil {
+		result, err := requestInfo.ResponseHandler(response, errorMappings)
 		if err != nil {
 			return nil, err
 		}
@@ -440,7 +440,7 @@ func (a *NetHttpRequestAdapter) SendPrimitiveCollectionAsync(ctx context.Context
 }
 
 // SendNoContentAsync executes the HTTP request specified by the given RequestInformation with no return content.
-func (a *NetHttpRequestAdapter) SendNoContentAsync(ctx context.Context, requestInfo *abs.RequestInformation, responseHandler abs.ResponseHandler, errorMappings abs.ErrorMappings) error {
+func (a *NetHttpRequestAdapter) SendNoContentAsync(ctx context.Context, requestInfo *abs.RequestInformation, errorMappings abs.ErrorMappings) error {
 	if requestInfo == nil {
 		return errors.New("requestInfo cannot be nil")
 	}
@@ -448,8 +448,8 @@ func (a *NetHttpRequestAdapter) SendNoContentAsync(ctx context.Context, requestI
 	if err != nil {
 		return err
 	}
-	if responseHandler != nil {
-		_, err := responseHandler(response, errorMappings)
+	if requestInfo.ResponseHandler != nil {
+		_, err := requestInfo.ResponseHandler(response, errorMappings)
 		return err
 	} else if response != nil {
 		defer a.purge(response)

--- a/nethttp_request_adapter.go
+++ b/nethttp_request_adapter.go
@@ -96,7 +96,7 @@ func (a *NetHttpRequestAdapter) getHttpResponseMessage(ctx context.Context, requ
 	if claims != "" {
 		additionalContext[claimsKey] = claims
 	}
-	err := a.authenticationProvider.AuthenticateRequest(requestInfo, additionalContext)
+	err := a.authenticationProvider.AuthenticateRequest(ctx, requestInfo, additionalContext)
 	if err != nil {
 		return nil, err
 	}
@@ -152,7 +152,6 @@ func (a *NetHttpRequestAdapter) setBaseUrlForRequestInformation(requestInfo *abs
 	requestInfo.PathParameters["baseurl"] = a.GetBaseUrl()
 }
 
-<<<<<<< HEAD
 const requestTimeOutInSeconds = 100
 
 func (a *NetHttpRequestAdapter) getRequestFromRequestInformation(ctx context.Context, requestInfo *abs.RequestInformation) (*nethttp.Request, error) {
@@ -189,7 +188,7 @@ func (a *NetHttpRequestAdapter) getRequestFromRequestInformation(ctx context.Con
 		}
 	}
 	for _, value := range requestInfo.GetRequestOptions() {
-		request = request.WithContext(context.WithValue(ctx.Context(), value.GetKey(), value))
+		request = request.WithContext(context.WithValue(ctx, value.GetKey(), value))
 	}
 	return request, nil
 }

--- a/nethttp_request_adapter.go
+++ b/nethttp_request_adapter.go
@@ -91,6 +91,9 @@ func (a *NetHttpRequestAdapter) GetBaseUrl() string {
 }
 
 func (a *NetHttpRequestAdapter) getHttpResponseMessage(ctx context.Context, requestInfo *abs.RequestInformation, claims string) (*nethttp.Response, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	a.setBaseUrlForRequestInformation(requestInfo)
 	additionalContext := make(map[string]interface{})
 	if claims != "" {
@@ -160,15 +163,10 @@ func (a *NetHttpRequestAdapter) getRequestFromRequestInformation(ctx context.Con
 		return nil, err
 	}
 
-	if ctx == nil {
-		ctx = context.Background()
-	}
-
 	// add deadline of not set
 	if _, deadlineSet := ctx.Deadline(); !deadlineSet {
-		ctxTimed, cancel := context.WithTimeout(ctx, time.Second*requestTimeOutInSeconds)
+		ctxTimed, _ := context.WithTimeout(ctx, time.Second*requestTimeOutInSeconds)
 		ctx = ctxTimed
-		defer cancel()
 	}
 
 	request, err := nethttp.NewRequestWithContext(ctx, requestInfo.Method.String(), uri.String(), nil)

--- a/nethttp_request_adapter_test.go
+++ b/nethttp_request_adapter_test.go
@@ -39,7 +39,7 @@ func TestItRetriesOnCAEResponse(t *testing.T) {
 	request.SetUri(*uri)
 	request.Method = abs.GET
 
-	err2 := adapter.SendNoContentAsync(context.TODO(), request, nil, nil)
+	err2 := adapter.SendNoContentAsync(context.TODO(), request, nil)
 	assert.Nil(t, err2)
 	assert.Equal(t, 2, methodCallCount)
 }
@@ -70,7 +70,7 @@ func TestItDoesntFailOnEmptyContentType(t *testing.T) {
 	request.SetUri(*uri)
 	request.Method = abs.GET
 
-	res, err := adapter.SendAsync(context.Background(), request, nil, nil, nil)
+	res, err := adapter.SendAsync(context.Background(), request, nil, nil)
 	assert.Nil(t, err)
 	assert.Nil(t, res)
 }

--- a/nethttp_request_adapter_test.go
+++ b/nethttp_request_adapter_test.go
@@ -1,6 +1,7 @@
 package nethttplibrary
 
 import (
+	"context"
 	nethttp "net/http"
 	httptest "net/http/httptest"
 	"net/url"
@@ -38,7 +39,7 @@ func TestItRetriesOnCAEResponse(t *testing.T) {
 	request.SetUri(*uri)
 	request.Method = abs.GET
 
-	err2 := adapter.SendNoContentAsync(request, nil, nil)
+	err2 := adapter.SendNoContentAsync(context.TODO(), request, nil, nil)
 	assert.Nil(t, err2)
 	assert.Equal(t, 2, methodCallCount)
 }
@@ -69,7 +70,7 @@ func TestItDoesntFailOnEmptyContentType(t *testing.T) {
 	request.SetUri(*uri)
 	request.Method = abs.GET
 
-	res, err := adapter.SendAsync(request, nil, nil, nil)
+	res, err := adapter.SendAsync(context.Background(), request, nil, nil, nil)
 	assert.Nil(t, err)
 	assert.Nil(t, res)
 }


### PR DESCRIPTION
Implements request adapter breaking change introduced by context object

Partial work on https://github.com/microsoftgraph/msgraph-sdk-go/issues/176

Fixes https://github.com/microsoftgraph/msgraph-sdk-go/issues/251
Fixes https://github.com/microsoftgraph/msgraph-sdk-go/issues/253