### PR TITLE
Adds a default 100 secs timeout per request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+## [0.6.2] - 2022-08-30
+
+### Added
+
+- Default 100 secs timeout for all request with a default context.
+
 ## [0.6.1] - 2022-08-29
 
 ### Changed

--- a/nethttp_request_adapter.go
+++ b/nethttp_request_adapter.go
@@ -7,6 +7,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 
 	ctx "context"
 	nethttp "net/http"
@@ -149,12 +150,19 @@ func (a *NetHttpRequestAdapter) getResponsePrimaryContentType(response *nethttp.
 func (a *NetHttpRequestAdapter) setBaseUrlForRequestInformation(requestInfo *abs.RequestInformation) {
 	requestInfo.PathParameters["baseurl"] = a.GetBaseUrl()
 }
+
+const requestTimeOutInSeconds = 100
+
 func (a *NetHttpRequestAdapter) getRequestFromRequestInformation(requestInfo *abs.RequestInformation) (*nethttp.Request, error) {
 	uri, err := requestInfo.GetUri()
 	if err != nil {
 		return nil, err
 	}
-	request, err := nethttp.NewRequest(requestInfo.Method.String(), uri.String(), nil)
+
+	context, cancel := ctx.WithTimeout(ctx.Background(), time.Second*requestTimeOutInSeconds)
+	defer cancel()
+
+	request, err := nethttp.NewRequestWithContext(context, requestInfo.Method.String(), uri.String(), nil)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Adds a 100 secs default timeout per request, users should be able to bypass the 100 secs timeout after `context refactor` https://github.com/microsoft/kiota-http-go/pull/22

Resolves https://github.com/microsoftgraph/msgraph-sdk-go-core/issues/6