### PR TITLE
- Fixes http.request_content_length attribute name for tracing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Fixed http.request_content_length attribute name for tracing
+
 ## [0.9.0] - 2022-09-27
 
 ### Added

--- a/nethttp_request_adapter.go
+++ b/nethttp_request_adapter.go
@@ -260,7 +260,7 @@ func (a *NetHttpRequestAdapter) getRequestFromRequestInformation(ctx context.Con
 		if request.Header.Get("Content-Length") != "" {
 			contentLenVal, _ := strconv.Atoi(request.Header.Get("Content-Length"))
 			spanForAttributes.SetAttributes(
-				attribute.Int("http.request_content_type", contentLenVal),
+				attribute.Int("http.request_content_length", contentLenVal),
 			)
 		}
 	}


### PR DESCRIPTION
Signed-off-by: Vincent Biret <vibiret@microsoft.com>
