### PR TITLE
Default context deadline to client timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+### Changed
+
+## [0.16.1] - 2023-03-20
+
+### Added
+
+- Context deadline for requests defaults to client timeout when not provided.
+
 ## [0.16.0] - 2023-03-01
 
 ### Added

--- a/kiota_client_factory.go
+++ b/kiota_client_factory.go
@@ -70,7 +70,7 @@ func getDefaultClientWithoutMiddleware() *nethttp.Client {
 		CheckRedirect: func(req *nethttp.Request, via []*nethttp.Request) error {
 			return nethttp.ErrUseLastResponse
 		},
-		Timeout: time.Second * 30,
+		Timeout: time.Second * 100,
 	}
 }
 


### PR DESCRIPTION
This change syncronizes the deafult context deadline and the client Timeout.  When a user does not pass a context deadline, the default fallback will not be the value of the client timeout. This should also make it possible to modify default context deadlines for a single point addressing https://github.com/microsoft/kiota-http-go/issues/70

Should also prevent the client timeout overriding the context timeout when its significantly lower https://github.com/microsoftgraph/msgraph-sdk-go/issues/302#issuecomment-1282421659

To modify a deadline, you can pass initialize `NetHttpRequestAdapter` with a modified `client.Timeout` property.

````go

client := GetDefaultClient()
client.Timeout = time.Second * 20

adapter := NewNetHttpRequestAdapterWithParseNodeFactoryAndSerializationWriterFactoryAndHttpClient(provider, nil, nil, client)

```
