### PR TITLE
Exit retry handler earlier if context is done

### DIFF
--- a/retry_handler.go
+++ b/retry_handler.go
@@ -152,6 +152,7 @@ func (middleware RetryHandler) retryRequest(ctx context.Context, pipeline Pipeli
 		select {
 		case <-ctx.Done():
 			// Return without retrying if the context was cancelled.
+			return nil, ctx.Err()
 
 			// Leaving this case empty causes it to exit the switch-block.
 		case <-t.C:

--- a/retry_handler.go
+++ b/retry_handler.go
@@ -152,14 +152,15 @@ func (middleware RetryHandler) retryRequest(ctx context.Context, pipeline Pipeli
 		select {
 		case <-ctx.Done():
 			// Return without retrying if the context was cancelled.
-			return nil, ctx.Err()
+
+			// Leaving this case empty causes it to exit the switch-block.
 		case <-t.C:
-			response, err := pipeline.Next(req, middlewareIndex)
-			if err != nil {
-				return response, err
-			}
-			return middleware.retryRequest(ctx, pipeline, middlewareIndex, options, req, response, executionCount, cumulativeDelay, observabilityName)
 		}
+		response, err := pipeline.Next(req, middlewareIndex)
+		if err != nil {
+			return response, err
+		}
+		return middleware.retryRequest(ctx, pipeline, middlewareIndex, options, req, response, executionCount, cumulativeDelay, observabilityName)
 	}
 	return resp, nil
 }


### PR DESCRIPTION
Retry handler doesn't currently handle context being cancelled or expiring during the retry delay. This can lead to situations where the handler sleeps for a long time due to a long `Retry-After` value but then exits with a `context deadline expired` or `context cancelled` error without actually sending a retry

This PR updates the logic for the sleep to exit early if the context is marked as done