### PR TITLE
Expose url replacement logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+## [0.16.2] - 2023-04-17
+
+### Added
+
+- Adds exported method `ReplacePathTokens` that can be used to process url replacement logic globally .
+
 ## [0.16.1] - 2023-03-20
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Adds exported method `ReplacePathTokens` that can be used to process url replacement logic globally .
+- Exit retry handler earlier if context is done.
+- Adds exported method `ReplacePathTokens` that can be used to process url replacement logic globally.
 
 ## [0.16.1] - 2023-03-20
 

--- a/url_replace_handler.go
+++ b/url_replace_handler.go
@@ -64,24 +64,13 @@ func (c *UrlReplaceHandler) Intercept(pipeline Pipeline, middlewareIndex int, re
 		return pipeline.Next(req, middlewareIndex)
 	}
 
-	err := c.replaceTokens(req, ReplacementPairs)
-	if err != nil {
-		if span != nil {
-			span.RecordError(err)
-		}
-		return nil, err
-	}
+	req.URL.Path = ReplacePathTokens(req.URL.Path, ReplacementPairs)
 
 	if span != nil {
 		span.SetAttributes(attribute.String("http.request_url", req.RequestURI))
 	}
 
 	return pipeline.Next(req, middlewareIndex)
-}
-
-func (c *UrlReplaceHandler) replaceTokens(request *http.Request, replacementPairs map[string]string) error {
-	request.URL.Path = ReplacePathTokens(request.URL.Path, replacementPairs)
-	return nil
 }
 
 // ReplacePathTokens invokes token replacement logic on the given url path

--- a/url_replace_handler_test.go
+++ b/url_replace_handler_test.go
@@ -27,7 +27,7 @@ func (pipeline *SpyPipeline) GetReceivedRequest() *nethttp.Request {
 
 func TestURLReplacementHandler(t *testing.T) {
 
-	handler := NewUrlReplaceHandler()
+	handler := NewUrlReplaceHandler(true, map[string]string{"/users/me-token-to-replace": "/me"})
 	if handler == nil {
 		t.Error("handler is nil")
 	}

--- a/user_agent_handler.go
+++ b/user_agent_handler.go
@@ -42,7 +42,7 @@ func NewUserAgentHandlerOptions() *UserAgentHandlerOptions {
 	return &UserAgentHandlerOptions{
 		Enabled:        true,
 		ProductName:    "kiota-go",
-		ProductVersion: "0.13.0",
+		ProductVersion: "0.16.2",
 	}
 }
 


### PR DESCRIPTION
This PR partially address [issue 179](https://github.com/microsoftgraph/msgraph-sdk-go-core/issues/179). Batch requests that rely on url replacement logic do not convert the request url for batch items.
The PR increases visibility of some private objects to allow method reuse in implementing libraries. (Reflection is not an option when attempting to invoke priavte methods on private objects)

1. `customTransport`  is now public and allows type casting to an interface to be specifically type `CustomTransport `
2. Method `customTransport.GetMiddleWares` returns the list of middle ware assigned to the trasnport object 
3. `UrlReplaceHandler.ReplacePathTokens` is now public to allow invoking the method outside the package.