### PR TITLE
Fixes redirect host URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+## [1.0.1] - 2023-07-19
+
+### Changed
+
+- Bug Fix: Update Host for Redirect URL in go client.
+
 ## [1.0.0] - 2023-05-04
 
 ### Changed

--- a/redirect_handler.go
+++ b/redirect_handler.go
@@ -161,6 +161,9 @@ func (middleware RedirectHandler) getRedirectRequest(request *nethttp.Request, r
 		return nil, err
 	}
 	result.URL = targetUrl
+	if result.Host != targetUrl.Host {
+		result.Host = targetUrl.Host
+	}
 	sameHost := strings.EqualFold(targetUrl.Host, request.URL.Host)
 	sameScheme := strings.EqualFold(targetUrl.Scheme, request.URL.Scheme)
 	if !sameHost || !sameScheme {

--- a/redirect_handler_test.go
+++ b/redirect_handler_test.go
@@ -110,5 +110,6 @@ func TestItStripsAuthorizationHeaderOnDifferentHost(t *testing.T) {
 		t.Error(err)
 	}
 	assert.NotNil(t, result)
+	assert.Equal(t, "www.bing.com", result.Host)
 	assert.Equal(t, "", result.Header.Get("Authorization"))
 }

--- a/user_agent_handler.go
+++ b/user_agent_handler.go
@@ -42,7 +42,7 @@ func NewUserAgentHandlerOptions() *UserAgentHandlerOptions {
 	return &UserAgentHandlerOptions{
 		Enabled:        true,
 		ProductName:    "kiota-go",
-		ProductVersion: "0.16.2",
+		ProductVersion: "1.0.1",
 	}
 }
 


### PR DESCRIPTION
Updates the redirect Host url that results to 400 errors when the redirect request host is not the same as the current host.

Fixes https://github.com/microsoftgraph/msgraph-sdk-go/issues/485
Fixes https://github.com/microsoft/kiota-http-go/issues/97