### PR TITLE
refactor(nethttp_request_adapter.go): As of Go 1.16, the functions in the ioutil package have been deprecated.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Changed the code by replacing ioutil.ReadAll and ioutil.NopCloser with io.ReadAll and io.NopCloser, respectively, due to their deprecation.
+- Changed the code by replacing ioutil.ReadAll and ioutil.NopCloser with io.ReadAll and io.NopCloser, respectively, due to their deprecation. 
+
 
 ## [1.1.1] - 2023-11-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+## [1.1.2] - 2024-01-20
+
+### Changed
+
+- Changed the code by replacing ioutil.ReadAll and ioutil.NopCloser with io.ReadAll and io.NopCloser, respectively, due to their deprecation.
+
 ## [1.1.1] - 2023-11-22
 
 ### Added

--- a/compression_handler.go
+++ b/compression_handler.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"compress/gzip"
 	"io"
-	"io/ioutil"
 	"net/http"
 
 	abstractions "github.com/microsoft/kiota-abstractions-go"
@@ -82,7 +81,7 @@ func (c *CompressionHandler) Intercept(pipeline Pipeline, middlewareIndex int, r
 		span.SetAttributes(attribute.Bool("http.request_body_compressed", true))
 	}
 
-	unCompressedBody, err := ioutil.ReadAll(req.Body)
+	unCompressedBody, err := io.ReadAll(req.Body)
 	unCompressedContentLength := req.ContentLength
 	if err != nil {
 		if span != nil {
@@ -116,7 +115,7 @@ func (c *CompressionHandler) Intercept(pipeline Pipeline, middlewareIndex int, r
 	// If response has status 415 retry request with uncompressed body
 	if resp.StatusCode == 415 {
 		delete(req.Header, "Content-Encoding")
-		req.Body = ioutil.NopCloser(bytes.NewBuffer(unCompressedBody))
+		req.Body = io.NopCloser(bytes.NewBuffer(unCompressedBody))
 		req.ContentLength = unCompressedContentLength
 
 		if span != nil {
@@ -141,5 +140,5 @@ func compressReqBody(reqBody []byte) (io.ReadCloser, int, error) {
 		return nil, 0, err
 	}
 
-	return ioutil.NopCloser(&buffer), buffer.Len(), nil
+	return io.NopCloser(&buffer), buffer.Len(), nil
 }

--- a/decompression_handler_test.go
+++ b/decompression_handler_test.go
@@ -3,7 +3,7 @@ package nethttplibrary
 import (
 	"compress/gzip"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	nethttp "net/http"
 	httptest "net/http/httptest"
 	"testing"
@@ -30,7 +30,7 @@ func TestTransportDecompressesResponse(t *testing.T) {
 	client.Transport = NewCustomTransport(NewCompressionHandler())
 
 	resp, _ := client.Get(testServer.URL)
-	respBody, _ := ioutil.ReadAll(resp.Body)
+	respBody, _ := io.ReadAll(resp.Body)
 
 	assert.True(t, resp.Uncompressed)
 	assert.Equal(t, string(respBody), `{"email":"Test@Test.com","name":"Test"}`)

--- a/nethttp_request_adapter.go
+++ b/nethttp_request_adapter.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"errors"
 	"io"
-	"io/ioutil"
 	nethttp "net/http"
 	"reflect"
 	"regexp"
@@ -566,7 +565,7 @@ func (a *NetHttpRequestAdapter) SendPrimitive(ctx context.Context, requestInfo *
 			return nil, nil
 		}
 		if typeName == "[]byte" {
-			res, err := ioutil.ReadAll(response.Body)
+			res, err := io.ReadAll(response.Body)
 			if err != nil {
 				span.RecordError(err)
 				return nil, err
@@ -702,7 +701,7 @@ func (a *NetHttpRequestAdapter) SendNoContent(ctx context.Context, requestInfo *
 func (a *NetHttpRequestAdapter) getRootParseNode(ctx context.Context, response *nethttp.Response, spanForAttributes trace.Span) (absser.ParseNode, context.Context, error) {
 	ctx, span := otel.GetTracerProvider().Tracer(a.observabilityOptions.GetTracerInstrumentationName()).Start(ctx, "getRootParseNode")
 	defer span.End()
-	body, err := ioutil.ReadAll(response.Body)
+	body, err := io.ReadAll(response.Body)
 	if err != nil {
 		spanForAttributes.RecordError(err)
 		return nil, ctx, err
@@ -718,7 +717,7 @@ func (a *NetHttpRequestAdapter) getRootParseNode(ctx context.Context, response *
 	return rootNode, ctx, err
 }
 func (a *NetHttpRequestAdapter) purge(response *nethttp.Response) error {
-	_, _ = ioutil.ReadAll(response.Body) //we don't care about errors comming from reading the body, just trying to purge anything that maybe left
+	_, _ = io.ReadAll(response.Body) //we don't care about errors comming from reading the body, just trying to purge anything that maybe left
 	err := response.Body.Close()
 	if err != nil {
 		return err

--- a/parameters_name_decoding_handler_test.go
+++ b/parameters_name_decoding_handler_test.go
@@ -15,15 +15,6 @@ func TestItDecodesQueryParameterNames(t *testing.T) {
 		{"?%24select=diplayName&api%2Eversion=2", "/?$select=diplayName&api.version=2"},
 		{"/api-version/?%24select=diplayName&api%2Eversion=2", "/api-version/?$select=diplayName&api.version=2"},
 		{"", "/"},
-		{"?q=1%2B2", "/?q=1%2B2"},                       //Values are not decoded
-		{"?q=M%26A", "/?q=M%26A"},                       //Values are not decoded
-		{"?q%2D1=M%26A", "/?q-1=M%26A"},                 //Values are not decoded but params are
-		{"?q%2D1&q=M%26A=M%26A", "/?q-1&q=M%26A=M%26A"}, //Values are not decoded but params are
-		{"?%24select=diplayName&api%2Dversion=1%2B2", "/?$select=diplayName&api-version=1%2B2"}, //Values are not decoded but params are
-		{"?%24select=diplayName&api%2Dversion=M%26A", "/?$select=diplayName&api-version=M%26A"}, //Values are not decoded but params are
-		{"?%24select=diplayName&api%7Eversion=M%26A", "/?$select=diplayName&api~version=M%26A"}, //Values are not decoded but params are
-		{"?%24select=diplayName&api%2Eversion=M%26A", "/?$select=diplayName&api.version=M%26A"}, //Values are not decoded but params are
-		{"?%24select=diplayName&api%2Eversion=M%26A", "/?$select=diplayName&api.version=M%26A"}, //Values are not decoded but params are
 	}
 	result := ""
 	testServer := httptest.NewServer(nethttp.HandlerFunc(func(res nethttp.ResponseWriter, req *nethttp.Request) {

--- a/parameters_name_decoding_handler_test.go
+++ b/parameters_name_decoding_handler_test.go
@@ -15,6 +15,15 @@ func TestItDecodesQueryParameterNames(t *testing.T) {
 		{"?%24select=diplayName&api%2Eversion=2", "/?$select=diplayName&api.version=2"},
 		{"/api-version/?%24select=diplayName&api%2Eversion=2", "/api-version/?$select=diplayName&api.version=2"},
 		{"", "/"},
+		{"?q=1%2B2", "/?q=1%2B2"},                       //Values are not decoded
+		{"?q=M%26A", "/?q=M%26A"},                       //Values are not decoded
+		{"?q%2D1=M%26A", "/?q-1=M%26A"},                 //Values are not decoded but params are
+		{"?q%2D1&q=M%26A=M%26A", "/?q-1&q=M%26A=M%26A"}, //Values are not decoded but params are
+		{"?%24select=diplayName&api%2Dversion=1%2B2", "/?$select=diplayName&api-version=1%2B2"}, //Values are not decoded but params are
+		{"?%24select=diplayName&api%2Dversion=M%26A", "/?$select=diplayName&api-version=M%26A"}, //Values are not decoded but params are
+		{"?%24select=diplayName&api%7Eversion=M%26A", "/?$select=diplayName&api~version=M%26A"}, //Values are not decoded but params are
+		{"?%24select=diplayName&api%2Eversion=M%26A", "/?$select=diplayName&api.version=M%26A"}, //Values are not decoded but params are
+		{"?%24select=diplayName&api%2Eversion=M%26A", "/?$select=diplayName&api.version=M%26A"}, //Values are not decoded but params are
 	}
 	result := ""
 	testServer := httptest.NewServer(nethttp.HandlerFunc(func(res nethttp.ResponseWriter, req *nethttp.Request) {
@@ -24,7 +33,6 @@ func TestItDecodesQueryParameterNames(t *testing.T) {
 	}))
 	defer func() { testServer.Close() }()
 	for _, data := range testData {
-
 		handler := NewParametersNameDecodingHandler()
 		input := testServer.URL + data[0]
 		expected := data[1]


### PR DESCRIPTION
As of Go 1.16, ioutil.ReadAll, ioutil.NopCloser were deprecated.