### PR TITLE
Adds support for XX status code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+## [1.2.0] - 2024-01-22
+
+### Added
+
+- Adds support for XXX status code.
+
 ## [1.1.1] - 2023-11-22
 
 ### Added

--- a/internal/mock_parse_node_factory.go
+++ b/internal/mock_parse_node_factory.go
@@ -57,6 +57,12 @@ func (e *MockParseNode) GetCollectionOfEnumValues(parser absser.EnumFactory) ([]
 	return nil, nil
 }
 func (e *MockParseNode) GetObjectValue(ctor absser.ParsableFactory) (absser.Parsable, error) {
+	if ctor != nil {
+		_, err := ctor(e)
+		if err != nil {
+			return nil, err
+		}
+	}
 	return &MockEntity{}, nil
 }
 func (e *MockParseNode) GetStringValue() (*string, error) {

--- a/nethttp_request_adapter.go
+++ b/nethttp_request_adapter.go
@@ -754,12 +754,12 @@ func (a *NetHttpRequestAdapter) throwIfFailedResponse(ctx context.Context, respo
 	if len(errorMappings) != 0 {
 		if errorMappings[statusAsString] != nil {
 			errorCtor = errorMappings[statusAsString]
-		} else if errorMappings["XXX"] != nil && response.StatusCode >= 400 && response.StatusCode < 600 {
-			errorCtor = errorMappings["XXX"]
 		} else if response.StatusCode >= 400 && response.StatusCode < 500 && errorMappings["4XX"] != nil {
 			errorCtor = errorMappings["4XX"]
 		} else if response.StatusCode >= 500 && response.StatusCode < 600 && errorMappings["5XX"] != nil {
 			errorCtor = errorMappings["5XX"]
+		} else if errorMappings["XXX"] != nil && response.StatusCode >= 400 && response.StatusCode < 600 {
+			errorCtor = errorMappings["XXX"]
 		}
 	}
 

--- a/nethttp_request_adapter.go
+++ b/nethttp_request_adapter.go
@@ -702,7 +702,7 @@ func (a *NetHttpRequestAdapter) SendNoContent(ctx context.Context, requestInfo *
 func (a *NetHttpRequestAdapter) getRootParseNode(ctx context.Context, response *nethttp.Response, spanForAttributes trace.Span) (absser.ParseNode, context.Context, error) {
 	ctx, span := otel.GetTracerProvider().Tracer(a.observabilityOptions.GetTracerInstrumentationName()).Start(ctx, "getRootParseNode")
 	defer span.End()
-	body, err := ioutil.ReadAll(response.Body)
+	body, err := io.ReadAll(response.Body)
 	if err != nil {
 		spanForAttributes.RecordError(err)
 		return nil, ctx, err
@@ -754,6 +754,8 @@ func (a *NetHttpRequestAdapter) throwIfFailedResponse(ctx context.Context, respo
 	if len(errorMappings) != 0 {
 		if errorMappings[statusAsString] != nil {
 			errorCtor = errorMappings[statusAsString]
+		} else if errorMappings["XXX"] != nil && response.StatusCode >= 400 && response.StatusCode < 600 {
+			errorCtor = errorMappings["XXX"]
 		} else if response.StatusCode >= 400 && response.StatusCode < 500 && errorMappings["4XX"] != nil {
 			errorCtor = errorMappings["4XX"]
 		} else if response.StatusCode >= 500 && response.StatusCode < 600 && errorMappings["5XX"] != nil {


### PR DESCRIPTION
Adds XXX error status mapping that can be used to represent both 4XX and 5XX status mappings

Resolves https://github.com/microsoft/kiota-http-go/issues/136