### PR TITLE
Fix context timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+## [1.1.2] - 2023-01-22
+
+### Changed
+
+- Fix bug passing no timeout in client as 0 timeout in context  .
+
 ## [1.1.1] - 2023-11-22
 
 ### Added

--- a/nethttp_request_adapter.go
+++ b/nethttp_request_adapter.go
@@ -215,7 +215,8 @@ func (a *NetHttpRequestAdapter) prepareContext(ctx context.Context, requestInfo 
 		ctx = context.Background()
 	}
 	// set deadline if not set in receiving context
-	if _, deadlineSet := ctx.Deadline(); !deadlineSet {
+	// ignore if timeout is 0 as it means no timeout
+	if _, deadlineSet := ctx.Deadline(); !deadlineSet && a.httpClient.Timeout != 0 {
 		ctx, _ = context.WithTimeout(ctx, a.httpClient.Timeout)
 	}
 


### PR DESCRIPTION
Fixes a bug where 0 value in the `httpClient.Timeout` refers to no timeout while a 0 value for http `context.WithTimeout` refers to 0 seconds to timeout. 

Prevent propagation of the default client timeout to the the context timeout when no client timeout is set

Resolves https://github.com/microsoft/kiota-http-go/issues/76