### PR TITLE
Return error and status not content is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+## [1.3.1] - 2024-02-09
+
+### Added
+
+### Changed
+
+- Fix bug that resulted in the error "content is empty" being returned instead of HTTP status information if the request returned no content and an unsuccessful status code.
+
 ## [1.3.0] - 2024-01-22
 
 ### Added

--- a/nethttp_request_adapter.go
+++ b/nethttp_request_adapter.go
@@ -702,6 +702,11 @@ func (a *NetHttpRequestAdapter) SendNoContent(ctx context.Context, requestInfo *
 func (a *NetHttpRequestAdapter) getRootParseNode(ctx context.Context, response *nethttp.Response, spanForAttributes trace.Span) (absser.ParseNode, context.Context, error) {
 	ctx, span := otel.GetTracerProvider().Tracer(a.observabilityOptions.GetTracerInstrumentationName()).Start(ctx, "getRootParseNode")
 	defer span.End()
+
+	if response.ContentLength == 0 {
+		return nil, ctx, nil
+	}
+
 	body, err := io.ReadAll(response.Body)
 	if err != nil {
 		spanForAttributes.RecordError(err)

--- a/user_agent_handler.go
+++ b/user_agent_handler.go
@@ -42,7 +42,7 @@ func NewUserAgentHandlerOptions() *UserAgentHandlerOptions {
 	return &UserAgentHandlerOptions{
 		Enabled:        true,
 		ProductName:    "kiota-go",
-		ProductVersion: "1.1.0",
+		ProductVersion: "1.3.1",
 	}
 }
 


### PR DESCRIPTION
Fix issue where unsuccessful responses with no content would return a "content is empty" error from various serialization libraries instead of information about the status code.

Add a regression test for this as well.