### PR TITLE
Allows pre-processing of response body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-## [1.3.1] - 2024-02-09
+## [1.4.0] - 2024-02-22
 
 ### Added
+
+- Allows pre-processing of response body in the response handler middleware.
+
+## [1.3.1] - 2024-02-09
 
 ### Changed
 

--- a/nethttp_request_adapter.go
+++ b/nethttp_request_adapter.go
@@ -573,10 +573,8 @@ func getProcessHandler(ctx context.Context) ProcessHandler {
 	if handlerOption != nil {
 		handler = handlerOption.(abs.RequestHandlerOption).GetResponseHandler()
 		// check of the option key implement HandlerType
-		if handlerType, ok := handlerOption.(HandlerType); ok {
+		if handlerType, ok := handlerOption.(ProcessHandler); ok {
 			isFinalHandler = handlerType.IsFinalHandler()
-		} else {
-			isFinalHandler = true
 		}
 	}
 

--- a/nethttp_request_adapter_test.go
+++ b/nethttp_request_adapter_test.go
@@ -341,7 +341,7 @@ func TestResponseHandlerIsCalledWhenProvided(t *testing.T) {
 }
 
 func TestNonFinalResponseHandlerIsCalled(t *testing.T) {
-	statusCodes := []int{200, 201, 202, 203, 204, 205}
+	statusCodes := []int{200, 201, 202, 203}
 
 	for i := 0; i < len(statusCodes); i++ {
 
@@ -372,7 +372,7 @@ func TestNonFinalResponseHandlerIsCalled(t *testing.T) {
 
 		res, err2 := adapter.Send(context.TODO(), request, internal.MockEntityFactory, nil)
 		assert.Nil(t, err2)
-		assert.Nil(t, res)
+		assert.NotNil(t, res)
 		assert.Equal(t, 2, count)
 	}
 }

--- a/process_handler.go
+++ b/process_handler.go
@@ -2,15 +2,9 @@ package nethttplibrary
 
 import abs "github.com/microsoft/kiota-abstractions-go"
 
-type HandlerType interface {
-	// IsFinalHandler returns true if the current handler is the last one in the chain
-	IsFinalHandler() bool
-}
-
 type ProcessHandler interface {
-	HandlerType
+	IsFinalHandler() bool
 	abs.RequestHandlerOption
-	GetResponseHandler() abs.ResponseHandler
 }
 
 type processHandler struct {

--- a/process_handler.go
+++ b/process_handler.go
@@ -1,0 +1,43 @@
+package nethttplibrary
+
+import abs "github.com/microsoft/kiota-abstractions-go"
+
+type HandlerType interface {
+	// IsFinalHandler returns true if the current handler is the last one in the chain
+	IsFinalHandler() bool
+}
+
+type ProcessHandler interface {
+	HandlerType
+	abs.RequestHandlerOption
+	GetResponseHandler() abs.ResponseHandler
+}
+
+type processHandler struct {
+	responseHandler abs.ResponseHandler
+	isFinalHandler  bool
+}
+
+// NewProcessHandler creates a new ProcessHandler object
+func NewProcessHandler(responseHandler abs.ResponseHandler, isFinalHandler bool) ProcessHandler {
+	return &processHandler{
+		responseHandler: responseHandler,
+		isFinalHandler:  isFinalHandler,
+	}
+}
+
+func (p *processHandler) GetResponseHandler() abs.ResponseHandler {
+	return p.responseHandler
+}
+
+func (p *processHandler) IsFinalHandler() bool {
+	return p.isFinalHandler && p.responseHandler != nil
+}
+
+func (p *processHandler) SetResponseHandler(responseHandler abs.ResponseHandler) {
+	p.responseHandler = responseHandler
+}
+
+func (p *processHandler) GetKey() abs.RequestOptionKey {
+	return abs.ResponseHandlerOptionKey
+}


### PR DESCRIPTION
Resolve https://github.com/microsoft/kiota-http-go/issues/153

Allow users to define a response handler that eventually hands over processing of the parseable to the net adapter.

Fix a bug that would throw an error if the ResponseHandler response is a nil value