### PR TITLE
Adds read content value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-## [1.3.1] - 2024-02-09
+## [1.4.0] - 2024-03-07
 
 ### Added
+
+- Returns an `io.ReadCloser` for streamed responses, allows passing an `io.ReadCloser` to request information.
+
+## [1.3.1] - 2024-02-09
 
 ### Changed
 

--- a/nethttp_request_adapter.go
+++ b/nethttp_request_adapter.go
@@ -278,6 +278,9 @@ func (a *NetHttpRequestAdapter) getRequestFromRequestInformation(ctx context.Con
 		reader := bytes.NewReader(requestInfo.Content)
 		request.Body = NopCloser(reader)
 	}
+	if requestInfo.ContentReader != nil {
+		request.Body = requestInfo.ContentReader
+	}
 	if request.Header == nil {
 		request.Header = make(nethttp.Header)
 	}
@@ -574,6 +577,9 @@ func (a *NetHttpRequestAdapter) SendPrimitive(ctx context.Context, requestInfo *
 				return nil, nil
 			}
 			return res, nil
+		}
+		if typeName == "io.ReadCloser" {
+			return response.Body, nil
 		}
 		parseNode, _, err := a.getRootParseNode(ctx, response, span)
 		if err != nil {


### PR DESCRIPTION
Process `io.ReadCloser` in request information. Allows returning an `io.ReadCloser` from reading requests

Partially resolves https://github.com/microsoftgraph/msgraph-sdk-go/issues/588
Blocked by https://github.com/microsoft/kiota-abstractions-go/pull/158