### PR TITLE
Allow custom response handlers to return nil result values

### DIFF
--- a/nethttp_request_adapter.go
+++ b/nethttp_request_adapter.go
@@ -337,6 +337,9 @@ func (a *NetHttpRequestAdapter) Send(ctx context.Context, requestInfo *abs.Reque
 			span.RecordError(err)
 			return nil, err
 		}
+		if result == nil {
+			return nil, nil
+		}
 		return result.(absser.Parsable), nil
 	} else if response != nil {
 		defer a.purge(response)


### PR DESCRIPTION
Maintain consistent behavior with the default handler by returning nil for HTTP responses with a status code of 204 or empty body.