### PR TITLE
Fixing compression issue if content-range header is present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+## [1.4.2] - 2024-07-16
+
+### Changed
+
+- Prevent compression if Content-Range header is present.
+- Fix bug which leads to a mission Content-Length header.
+
 ## [1.4.1] - 2024-05-09
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Prevent compression if Content-Range header is present.
-- Fix bug which leads to a mission Content-Length header.
+- Fix bug which leads to a missing Content-Length header.
 
 ## [1.4.1] - 2024-05-09
 

--- a/compression_handler.go
+++ b/compression_handler.go
@@ -5,6 +5,7 @@ import (
 	"compress/gzip"
 	"io"
 	"net/http"
+	"strings"
 
 	abstractions "github.com/microsoft/kiota-abstractions-go"
 	"go.opentelemetry.io/otel"

--- a/compression_handler.go
+++ b/compression_handler.go
@@ -74,7 +74,7 @@ func (c *CompressionHandler) Intercept(pipeline Pipeline, middlewareIndex int, r
 		req = req.WithContext(ctx)
 	}
 
-	if !reqOption.ShouldCompress() || req.Body == nil {
+	if !reqOption.ShouldCompress() || contentRangeIsPresent(req.Header) || req.Body == nil {
 		return pipeline.Next(req, middlewareIndex)
 	}
 	if span != nil {
@@ -127,6 +127,11 @@ func (c *CompressionHandler) Intercept(pipeline Pipeline, middlewareIndex int, r
 	}
 
 	return resp, nil
+}
+
+func contentRangeIsPresent(header http.Header) bool {
+	_, contentRangePresent := header["Content-Range"]
+	return contentRangePresent
 }
 
 func compressReqBody(reqBody []byte) (io.ReadCloser, int, error) {

--- a/compression_handler.go
+++ b/compression_handler.go
@@ -35,7 +35,7 @@ func NewCompressionHandler() *CompressionHandler {
 	return NewCompressionHandlerWithOptions(options)
 }
 
-// NewCompressionHandlerWithOptions creates an instance of the compression middlerware with
+// NewCompressionHandlerWithOptions creates an instance of the compression middleware with
 // specified configurations.
 func NewCompressionHandlerWithOptions(option CompressionOptions) *CompressionHandler {
 	return &CompressionHandler{options: option}

--- a/compression_handler_test.go
+++ b/compression_handler_test.go
@@ -42,7 +42,7 @@ func TestCompressionHandlerAddsContentEncodingHeader(t *testing.T) {
 	assert.Equal(t, contentTypeHeader, "gzip")
 }
 
-func TestCopmressionHandlerCopmressesRequestBody(t *testing.T) {
+func TestCompressionHandlerCompressesRequestBody(t *testing.T) {
 	postBody, _ := json.Marshal(map[string]string{"name": `Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source. Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of "de Finibus Bonorum et Malorum" (The Extremes of Good and Evil) by Cicero, written in 45 BC. This book is a treatise on the theory of ethics, very popular during the Renaissance. The first line of Lorem Ipsum, "Lorem ipsum dolor sit amet..", comes from Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.a line in section 1.10.32.
     `, "email": "Test@Test.com"})
 	var compressedBody []byte
@@ -57,6 +57,24 @@ func TestCopmressionHandlerCopmressesRequestBody(t *testing.T) {
 
 	assert.Greater(t, len(postBody), len(compressedBody))
 
+}
+
+func TestCompressionHandlerContentRangeRequestBody(t *testing.T) {
+	postBody, _ := json.Marshal(map[string]string{"name": `Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source. Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of "de Finibus Bonorum et Malorum" (The Extremes of Good and Evil) by Cicero, written in 45 BC. This book is a treatise on the theory of ethics, very popular during the Renaissance. The first line of Lorem Ipsum, "Lorem ipsum dolor sit amet..", comes from Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.a line in section 1.10.32.
+    `, "email": "Test@Test.com"})
+	var compressedBody []byte
+	testServer := httptest.NewServer(nethttp.HandlerFunc(func(res nethttp.ResponseWriter, req *nethttp.Request) {
+		compressedBody, _ = io.ReadAll(req.Body)
+		fmt.Fprint(res, `{}`)
+	}))
+	defer testServer.Close()
+
+	client := GetDefaultClient(NewCompressionHandler())
+	req, _ := nethttp.NewRequest("PUT", testServer.URL, bytes.NewBuffer(postBody))
+	req.Header.Add("Content-Range", "bytes 0-3/4")
+	client.Do(req)
+
+	assert.Equal(t, len(postBody), len(compressedBody))
 }
 
 func TestCompressionHandlerRetriesRequest(t *testing.T) {

--- a/nethttp_request_adapter.go
+++ b/nethttp_request_adapter.go
@@ -295,6 +295,7 @@ func (a *NetHttpRequestAdapter) getRequestFromRequestInformation(ctx context.Con
 		}
 		if request.Header.Get("Content-Length") != "" {
 			contentLenVal, _ := strconv.Atoi(request.Header.Get("Content-Length"))
+			request.ContentLength = int64(contentLenVal)
 			spanForAttributes.SetAttributes(
 				attribute.Int("http.request_content_length", contentLenVal),
 			)


### PR DESCRIPTION
- Don't compress body if content-range header is present
- Set content-size header if it's present in the abstract headers

This should fix this issue:
https://github.com/microsoftgraph/msgraph-sdk-go-core/issues/295
