### PR TITLE
Return ReadSeekCloser from compression middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added
+## [1.4.5] - 2024-09-03
+
+### Changed
+- Fixed a bug in compression middleware which caused empty body to send on retries
 
 ## [1.4.4] - 2024-08-13
 

--- a/compression_handler.go
+++ b/compression_handler.go
@@ -145,7 +145,7 @@ func contentEncodingIsPresent(header http.Header) bool {
 	return ok
 }
 
-func compressReqBody(reqBody []byte) (io.ReadCloser, int, error) {
+func compressReqBody(reqBody []byte) (io.ReadSeekCloser, int, error) {
 	var buffer bytes.Buffer
 	gzipWriter := gzip.NewWriter(&buffer)
 	if _, err := gzipWriter.Write(reqBody); err != nil {
@@ -156,5 +156,6 @@ func compressReqBody(reqBody []byte) (io.ReadCloser, int, error) {
 		return nil, 0, err
 	}
 
-	return io.NopCloser(&buffer), buffer.Len(), nil
+	reader := bytes.NewReader(buffer.Bytes())
+	return NopCloser(reader), buffer.Len(), nil
 }

--- a/compression_handler_test.go
+++ b/compression_handler_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net/http"
 	nethttp "net/http"
 	httptest "net/http/httptest"
 	"testing"
@@ -57,6 +58,33 @@ func TestCompressionHandlerCompressesRequestBody(t *testing.T) {
 
 	assert.Greater(t, len(postBody), len(compressedBody))
 
+}
+
+func TestCompressionHandlerCompressesRequestBodyWithRetry(t *testing.T) {
+	postBody, _ := json.Marshal(map[string]string{"name": `Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source. Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of "de Finibus Bonorum et Malorum" (The Extremes of Good and Evil) by Cicero, written in 45 BC. This book is a treatise on the theory of ethics, very popular during the Renaissance. The first line of Lorem Ipsum, "Lorem ipsum dolor sit amet..", comes from Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.a line in section 1.10.32.
+    `, "email": "Test@Test.com"})
+
+	var compressedBody []byte
+	var requestCount int
+	testServer := httptest.NewServer(nethttp.HandlerFunc(func(res nethttp.ResponseWriter, req *nethttp.Request) {
+		if requestCount == 0 {
+			res.WriteHeader(http.StatusTooManyRequests)
+			requestCount++
+			return
+		}
+
+		compressedBody, _ = io.ReadAll(req.Body)
+		fmt.Fprint(res, `{}`)
+	}))
+	defer testServer.Close()
+
+	client := GetDefaultClient(NewCompressionHandler(), NewRetryHandler())
+	_, err := client.Post(testServer.URL, "application/json", bytes.NewBuffer(postBody))
+
+	assert.NotZero(t, len(compressedBody))
+	assert.Greater(t, len(postBody), len(compressedBody))
+	assert.Equal(t, requestCount, 1)
+	assert.NoError(t, err)
 }
 
 func TestCompressionHandlerContentRangeRequestBody(t *testing.T) {

--- a/user_agent_handler.go
+++ b/user_agent_handler.go
@@ -42,7 +42,7 @@ func NewUserAgentHandlerOptions() *UserAgentHandlerOptions {
 	return &UserAgentHandlerOptions{
 		Enabled:        true,
 		ProductName:    "kiota-go",
-		ProductVersion: "1.4.4",
+		ProductVersion: "1.4.5",
 	}
 }
 


### PR DESCRIPTION
This is necessary as retry logic requires the ability to seek the request body before retrying or the body ends up as empty.

Fixes https://github.com/microsoft/kiota-http-go/issues/183 as long as compression middleware is before retry logic.