### PR TITLE
fix(spans): adhere attribute name to otel semver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,17 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.4.7] - 2024-12-13
-
-### Changed
-
-- Updated HTTP span attributes to comply with updated OpenTelemetry semantic conventions. [#182](https://github.com/microsoft/kiota-http-go/issues/182)
-
 ## [1.4.6] - 2024-12-13
 
 ### Changed
 
 - Fixed a bug where headers inspection handler would fail upon receiving an error.
+- Updated HTTP span attributes to comply with updated OpenTelemetry semantic conventions. [#182](https://github.com/microsoft/kiota-http-go/issues/182)
 
 ## [1.4.5] - 2024-09-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.7] - 2024-12-13
+
+### Changed
+
+- Updated HTTP span attributes to comply with updated OpenTelemetry semantic conventions. [#182](https://github.com/microsoft/kiota-http-go/issues/182)
+
 ## [1.4.6] - 2024-12-13
 
 ### Changed
 
 - Fixed a bug where headers inspection handler would fail upon receiving an error.
-- Updated HTTP span attributes to comply with updated OpenTelemetry semantic conventions. [#182](https://github.com/microsoft/kiota-http-go/issues/182)
 
 ## [1.4.5] - 2024-09-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.6] - 2024-10-12
+
+### Changed
+
+- Updated HTTP span attributes to comply with updated OpenTelemetry semantic conventions. [#182](https://github.com/microsoft/kiota-http-go/issues/182)
+
 ## [1.4.5] - 2024-09-03
 
 ### Changed

--- a/compression_handler.go
+++ b/compression_handler.go
@@ -10,7 +10,6 @@ import (
 	abstractions "github.com/microsoft/kiota-abstractions-go"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
-	semconv "go.opentelemetry.io/otel/semconv/v1.24.0"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -105,7 +104,7 @@ func (c *CompressionHandler) Intercept(pipeline Pipeline, middlewareIndex int, r
 	req.ContentLength = int64(size)
 
 	if span != nil {
-		span.SetAttributes(semconv.HTTPRequestBodySize(int(req.ContentLength)))
+		span.SetAttributes(HttpRequestBodySizeAttribute.Int(int(req.ContentLength)))
 	}
 
 	// Sending request with compressed body
@@ -121,8 +120,8 @@ func (c *CompressionHandler) Intercept(pipeline Pipeline, middlewareIndex int, r
 		req.ContentLength = unCompressedContentLength
 
 		if span != nil {
-			span.SetAttributes(semconv.HTTPRequestBodySize(int(req.ContentLength)),
-				semconv.HTTPResponseStatusCode(415))
+			span.SetAttributes(HttpRequestBodySizeAttribute.Int(int(req.ContentLength)),
+				HttpResponseStatusCodeAttribute.Int(415))
 		}
 
 		return pipeline.Next(req, middlewareIndex)

--- a/compression_handler.go
+++ b/compression_handler.go
@@ -104,7 +104,7 @@ func (c *CompressionHandler) Intercept(pipeline Pipeline, middlewareIndex int, r
 	req.ContentLength = int64(size)
 
 	if span != nil {
-		span.SetAttributes(HttpRequestBodySizeAttribute.Int(int(req.ContentLength)))
+		span.SetAttributes(httpRequestBodySizeAttribute.Int(int(req.ContentLength)))
 	}
 
 	// Sending request with compressed body
@@ -120,8 +120,8 @@ func (c *CompressionHandler) Intercept(pipeline Pipeline, middlewareIndex int, r
 		req.ContentLength = unCompressedContentLength
 
 		if span != nil {
-			span.SetAttributes(HttpRequestBodySizeAttribute.Int(int(req.ContentLength)),
-				HttpResponseStatusCodeAttribute.Int(415))
+			span.SetAttributes(httpRequestBodySizeAttribute.Int(int(req.ContentLength)),
+				httpResponseStatusCodeAttribute.Int(415))
 		}
 
 		return pipeline.Next(req, middlewareIndex)

--- a/compression_handler.go
+++ b/compression_handler.go
@@ -10,6 +10,7 @@ import (
 	abstractions "github.com/microsoft/kiota-abstractions-go"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
+	semconv "go.opentelemetry.io/otel/semconv/v1.24.0"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -104,7 +105,7 @@ func (c *CompressionHandler) Intercept(pipeline Pipeline, middlewareIndex int, r
 	req.ContentLength = int64(size)
 
 	if span != nil {
-		span.SetAttributes(attribute.Int64("http.request_content_length", req.ContentLength))
+		span.SetAttributes(semconv.HTTPRequestBodySize(int(req.ContentLength)))
 	}
 
 	// Sending request with compressed body
@@ -120,8 +121,8 @@ func (c *CompressionHandler) Intercept(pipeline Pipeline, middlewareIndex int, r
 		req.ContentLength = unCompressedContentLength
 
 		if span != nil {
-			span.SetAttributes(attribute.Int64("http.request_content_length", req.ContentLength),
-				attribute.Int("http.request_content_length", 415))
+			span.SetAttributes(semconv.HTTPRequestBodySize(int(req.ContentLength)),
+				semconv.HTTPResponseStatusCode(415))
 		}
 
 		return pipeline.Next(req, middlewareIndex)

--- a/nethttp_request_adapter.go
+++ b/nethttp_request_adapter.go
@@ -178,7 +178,7 @@ func (a *NetHttpRequestAdapter) retryCAEResponseIfRequired(ctx context.Context, 
 		authenticateHeaderVal := response.Header.Get("WWW-Authenticate")
 		if authenticateHeaderVal != "" && reBearer.Match([]byte(authenticateHeaderVal)) {
 			span.AddEvent(AuthenticateChallengedEventKey)
-			spanForAttributes.SetAttributes(attribute.Int("http.retry_count", 1))
+			spanForAttributes.SetAttributes(semconv.HTTPRequestResendCount(1))
 			responseClaims := ""
 			parametersRaw := string(reBearer.ReplaceAll([]byte(authenticateHeaderVal), []byte("")))
 			parameters := strings.Split(parametersRaw, ",")

--- a/nethttp_request_adapter.go
+++ b/nethttp_request_adapter.go
@@ -313,7 +313,7 @@ func (a *NetHttpRequestAdapter) startTracingSpan(ctx context.Context, requestInf
 	decodedUriTemplate := decodeUriEncodedString(requestInfo.UrlTemplate, []byte{'-', '.', '~', '$'})
 	telemetryPathValue := queryParametersCleanupRegex.ReplaceAll([]byte(decodedUriTemplate), []byte(""))
 	ctx, span := otel.GetTracerProvider().Tracer(a.observabilityOptions.GetTracerInstrumentationName()).Start(ctx, methodName+" - "+string(telemetryPathValue))
-	span.SetAttributes(UrlUriSchemeAttribute.String(decodedUriTemplate))
+	span.SetAttributes(UrlUriTemplateAttribute.String(decodedUriTemplate))
 	return ctx, span
 }
 

--- a/nethttp_request_adapter.go
+++ b/nethttp_request_adapter.go
@@ -290,7 +290,7 @@ func (a *NetHttpRequestAdapter) getRequestFromRequestInformation(ctx context.Con
 		}
 		if request.Header.Get("Content-Type") != "" {
 			spanForAttributes.SetAttributes(
-				attribute.String("http.request.header.content-type", request.Header.Get("Content-Type")),
+				HttpRequestHeaderContentTypeAttribute.String(request.Header.Get("Content-Type")),
 			)
 		}
 		if request.Header.Get("Content-Length") != "" {

--- a/redirect_handler.go
+++ b/redirect_handler.go
@@ -120,7 +120,7 @@ func (middleware RedirectHandler) redirectRequest(ctx context.Context, pipeline 
 		if observabilityName != "" {
 			ctx, span := otel.GetTracerProvider().Tracer(observabilityName).Start(ctx, "RedirectHandler_Intercept - redirect "+fmt.Sprint(redirectCount))
 			span.SetAttributes(attribute.Int("com.microsoft.kiota.handler.redirect.count", redirectCount),
-				HttpResponseStatusCodeAttribute.Int(response.StatusCode),
+				httpResponseStatusCodeAttribute.Int(response.StatusCode),
 			)
 			defer span.End()
 			redirectRequest = redirectRequest.WithContext(ctx)

--- a/redirect_handler.go
+++ b/redirect_handler.go
@@ -11,7 +11,6 @@ import (
 	abs "github.com/microsoft/kiota-abstractions-go"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
-	semconv "go.opentelemetry.io/otel/semconv/v1.24.0"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -121,7 +120,7 @@ func (middleware RedirectHandler) redirectRequest(ctx context.Context, pipeline 
 		if observabilityName != "" {
 			ctx, span := otel.GetTracerProvider().Tracer(observabilityName).Start(ctx, "RedirectHandler_Intercept - redirect "+fmt.Sprint(redirectCount))
 			span.SetAttributes(attribute.Int("com.microsoft.kiota.handler.redirect.count", redirectCount),
-				semconv.HTTPResponseStatusCode(response.StatusCode),
+				HttpResponseStatusCodeAttribute.Int(response.StatusCode),
 			)
 			defer span.End()
 			redirectRequest = redirectRequest.WithContext(ctx)

--- a/redirect_handler.go
+++ b/redirect_handler.go
@@ -11,6 +11,7 @@ import (
 	abs "github.com/microsoft/kiota-abstractions-go"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
+	semconv "go.opentelemetry.io/otel/semconv/v1.24.0"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -120,7 +121,7 @@ func (middleware RedirectHandler) redirectRequest(ctx context.Context, pipeline 
 		if observabilityName != "" {
 			ctx, span := otel.GetTracerProvider().Tracer(observabilityName).Start(ctx, "RedirectHandler_Intercept - redirect "+fmt.Sprint(redirectCount))
 			span.SetAttributes(attribute.Int("com.microsoft.kiota.handler.redirect.count", redirectCount),
-				attribute.Int("http.status_code", response.StatusCode),
+				semconv.HTTPResponseStatusCode(response.StatusCode),
 			)
 			defer span.End()
 			redirectRequest = redirectRequest.WithContext(ctx)

--- a/retry_handler.go
+++ b/retry_handler.go
@@ -144,7 +144,7 @@ func (middleware RetryHandler) retryRequest(ctx context.Context, pipeline Pipeli
 			ctx, span := otel.GetTracerProvider().Tracer(observabilityName).Start(ctx, "RetryHandler_Intercept - attempt "+fmt.Sprint(executionCount))
 			span.SetAttributes(attribute.Int("http.request.resend_count", executionCount),
 
-				HttpResponseStatusCodeAttribute.Int(resp.StatusCode),
+				httpResponseStatusCodeAttribute.Int(resp.StatusCode),
 				attribute.Float64("http.request.resend_delay", delay.Seconds()),
 			)
 			defer span.End()

--- a/retry_handler.go
+++ b/retry_handler.go
@@ -12,7 +12,6 @@ import (
 	abs "github.com/microsoft/kiota-abstractions-go"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
-	semconv "go.opentelemetry.io/otel/semconv/v1.24.0"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -145,7 +144,7 @@ func (middleware RetryHandler) retryRequest(ctx context.Context, pipeline Pipeli
 			ctx, span := otel.GetTracerProvider().Tracer(observabilityName).Start(ctx, "RetryHandler_Intercept - attempt "+fmt.Sprint(executionCount))
 			span.SetAttributes(attribute.Int("http.request.resend_count", executionCount),
 
-				semconv.HTTPResponseStatusCode(resp.StatusCode),
+				HttpResponseStatusCodeAttribute.Int(resp.StatusCode),
 				attribute.Float64("http.request.resend_delay", delay.Seconds()),
 			)
 			defer span.End()

--- a/retry_handler.go
+++ b/retry_handler.go
@@ -12,6 +12,7 @@ import (
 	abs "github.com/microsoft/kiota-abstractions-go"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
+	semconv "go.opentelemetry.io/otel/semconv/v1.24.0"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -144,9 +145,8 @@ func (middleware RetryHandler) retryRequest(ctx context.Context, pipeline Pipeli
 			ctx, span := otel.GetTracerProvider().Tracer(observabilityName).Start(ctx, "RetryHandler_Intercept - attempt "+fmt.Sprint(executionCount))
 			span.SetAttributes(attribute.Int("http.request.resend_count", executionCount),
 
-				attribute.Int("http.status_code", resp.StatusCode),
+				semconv.HTTPResponseStatusCode(resp.StatusCode),
 				attribute.Float64("http.request.resend_delay", delay.Seconds()),
-
 			)
 			defer span.End()
 			req = req.WithContext(ctx)

--- a/span_attributes.go
+++ b/span_attributes.go
@@ -12,7 +12,7 @@ const (
 // HTTP Response attributes
 const (
 	HttpResponseBodySizeAttribute          = attribute.Key("http.response.body.size")
-	HttpResponseHeaderContentTypeAttribute = attribute.Key("http.response.header.content_type")
+	HttpResponseHeaderContentTypeAttribute = attribute.Key("http.response.header.content-type")
 	HttpResponseStatusCodeAttribute        = attribute.Key("http.response.status_code")
 )
 
@@ -30,5 +30,5 @@ const (
 const (
 	UrlFullAttribute      = attribute.Key("url.full")
 	UrlSchemeAttribute    = attribute.Key("url.scheme")
-	UrlUriSchemeAttribute = attribute.Key("url.uri_scheme")
+	UrlUriTemplateAttribute = attribute.Key("url.uri_template")
 )

--- a/span_attributes.go
+++ b/span_attributes.go
@@ -1,0 +1,34 @@
+package nethttplibrary
+
+import "go.opentelemetry.io/otel/attribute"
+
+// HTTP Request attributes
+const (
+	HttpRequestBodySizeAttribute    = attribute.Key("http.request.body.size")
+	HttpRequestResendCountAttribute = attribute.Key("http.request.resend_count")
+	HttpRequestMethodAttribute      = attribute.Key("http.request.method")
+)
+
+// HTTP Response attributes
+const (
+	HttpResponseBodySizeAttribute          = attribute.Key("http.response.body.size")
+	HttpResponseHeaderContentTypeAttribute = attribute.Key("http.response.header.content_type")
+	HttpResponseStatusCodeAttribute        = attribute.Key("http.response.status_code")
+)
+
+// Network attributes
+const (
+	NetworkProtocolNameAttribute = attribute.Key("network.protocol.name")
+)
+
+// Server attributes
+const (
+	ServerAddressAttribute = attribute.Key("server.address")
+)
+
+// URL attributes
+const (
+	UrlFullAttribute      = attribute.Key("url.full")
+	UrlSchemeAttribute    = attribute.Key("url.scheme")
+	UrlUriSchemeAttribute = attribute.Key("url.uri_scheme")
+)

--- a/span_attributes.go
+++ b/span_attributes.go
@@ -4,32 +4,32 @@ import "go.opentelemetry.io/otel/attribute"
 
 // HTTP Request attributes
 const (
-	HttpRequestBodySizeAttribute          = attribute.Key("http.request.body.size")
-	HttpRequestResendCountAttribute       = attribute.Key("http.request.resend_count")
-	HttpRequestMethodAttribute            = attribute.Key("http.request.method")
-	HttpRequestHeaderContentTypeAttribute = attribute.Key("http.request.header.content-type")
+	httpRequestBodySizeAttribute          = attribute.Key("http.request.body.size")
+	httpRequestResendCountAttribute       = attribute.Key("http.request.resend_count")
+	httpRequestMethodAttribute            = attribute.Key("http.request.method")
+	httpRequestHeaderContentTypeAttribute = attribute.Key("http.request.header.content-type")
 )
 
 // HTTP Response attributes
 const (
-	HttpResponseBodySizeAttribute          = attribute.Key("http.response.body.size")
-	HttpResponseHeaderContentTypeAttribute = attribute.Key("http.response.header.content-type")
-	HttpResponseStatusCodeAttribute        = attribute.Key("http.response.status_code")
+	httpResponseBodySizeAttribute          = attribute.Key("http.response.body.size")
+	httpResponseHeaderContentTypeAttribute = attribute.Key("http.response.header.content-type")
+	httpResponseStatusCodeAttribute        = attribute.Key("http.response.status_code")
 )
 
 // Network attributes
 const (
-	NetworkProtocolNameAttribute = attribute.Key("network.protocol.name")
+	networkProtocolNameAttribute = attribute.Key("network.protocol.name")
 )
 
 // Server attributes
 const (
-	ServerAddressAttribute = attribute.Key("server.address")
+	serverAddressAttribute = attribute.Key("server.address")
 )
 
 // URL attributes
 const (
-	UrlFullAttribute        = attribute.Key("url.full")
-	UrlSchemeAttribute      = attribute.Key("url.scheme")
-	UrlUriTemplateAttribute = attribute.Key("url.uri_template")
+	urlFullAttribute        = attribute.Key("url.full")
+	urlSchemeAttribute      = attribute.Key("url.scheme")
+	urlUriTemplateAttribute = attribute.Key("url.uri_template")
 )

--- a/span_attributes.go
+++ b/span_attributes.go
@@ -4,9 +4,10 @@ import "go.opentelemetry.io/otel/attribute"
 
 // HTTP Request attributes
 const (
-	HttpRequestBodySizeAttribute    = attribute.Key("http.request.body.size")
-	HttpRequestResendCountAttribute = attribute.Key("http.request.resend_count")
-	HttpRequestMethodAttribute      = attribute.Key("http.request.method")
+	HttpRequestBodySizeAttribute          = attribute.Key("http.request.body.size")
+	HttpRequestResendCountAttribute       = attribute.Key("http.request.resend_count")
+	HttpRequestMethodAttribute            = attribute.Key("http.request.method")
+	HttpRequestHeaderContentTypeAttribute = attribute.Key("http.request.header.content-type")
 )
 
 // HTTP Response attributes
@@ -28,7 +29,7 @@ const (
 
 // URL attributes
 const (
-	UrlFullAttribute      = attribute.Key("url.full")
-	UrlSchemeAttribute    = attribute.Key("url.scheme")
+	UrlFullAttribute        = attribute.Key("url.full")
+	UrlSchemeAttribute      = attribute.Key("url.scheme")
 	UrlUriTemplateAttribute = attribute.Key("url.uri_template")
 )

--- a/user_agent_handler.go
+++ b/user_agent_handler.go
@@ -42,7 +42,7 @@ func NewUserAgentHandlerOptions() *UserAgentHandlerOptions {
 	return &UserAgentHandlerOptions{
 		Enabled:        true,
 		ProductName:    "kiota-go",
-		ProductVersion: "1.4.6",
+		ProductVersion: "1.4.7",
 	}
 }
 

--- a/user_agent_handler.go
+++ b/user_agent_handler.go
@@ -42,7 +42,7 @@ func NewUserAgentHandlerOptions() *UserAgentHandlerOptions {
 	return &UserAgentHandlerOptions{
 		Enabled:        true,
 		ProductName:    "kiota-go",
-		ProductVersion: "1.4.5",
+		ProductVersion: "1.4.6",
 	}
 }
 


### PR DESCRIPTION
Updates the http span attributes to match with the updated OTEL specification.

Fixes #182 