### PR TITLE
fix: adding middleware with options errors with "unsupported option type"

### DIFF
--- a/compression_handler.go
+++ b/compression_handler.go
@@ -32,8 +32,8 @@ var compressKey = abstractions.RequestOptionKey{Key: "CompressionHandler"}
 
 // NewCompressionHandler creates an instance of a compression middleware
 func NewCompressionHandler() *CompressionHandler {
-	options := NewCompressionOptions(true)
-	return NewCompressionHandlerWithOptions(options)
+	options := NewCompressionOptionsReference(true)
+	return NewCompressionHandlerWithOptions(*options)
 }
 
 // NewCompressionHandlerWithOptions creates an instance of the compression middleware with
@@ -43,8 +43,20 @@ func NewCompressionHandlerWithOptions(option CompressionOptions) *CompressionHan
 }
 
 // NewCompressionOptions creates a configuration object for the CompressionHandler
+//
+// Deprecated: This function is deprecated, and superseded by NewCompressionOptionsReference,
+// which returns a pointer instead of plain value.
 func NewCompressionOptions(enableCompression bool) CompressionOptions {
 	return CompressionOptions{enableCompression: enableCompression}
+}
+
+// NewCompressionOptionsReference creates a configuration object for the CompressionHandler.
+//
+// This function supersedes the NewCompressionOptions function and returns a pointer,
+// which is expected by GetDefaultMiddlewaresWithOptions.
+func NewCompressionOptionsReference(enableCompression bool) *CompressionOptions {
+	options := CompressionOptions{enableCompression: enableCompression}
+	return &options
 }
 
 // GetKey returns CompressionOptions unique name in context object

--- a/kiota_client_factory.go
+++ b/kiota_client_factory.go
@@ -98,6 +98,9 @@ func GetDefaultMiddlewaresWithOptions(requestOptions ...abs.RequestOption) ([]Mi
 			middlewareMap[redirectKeyValue] = NewRedirectHandlerWithOptions(*v)
 		case *CompressionOptions:
 			middlewareMap[compressKey] = NewCompressionHandlerWithOptions(*v)
+		case CompressionOptions:
+			println("deprecation notice: function GetDefaultMiddlewaresWithOptions expects a pointer to CompressionOptions. Use the NewCompressionOptionsReference convenience function.")
+			middlewareMap[compressKey] = NewCompressionHandlerWithOptions(v)
 		case *ParametersNameDecodingOptions:
 			middlewareMap[parametersNameDecodingKeyValue] = NewParametersNameDecodingHandlerWithOptions(*v)
 		case *UserAgentHandlerOptions:

--- a/kiota_client_factory_test.go
+++ b/kiota_client_factory_test.go
@@ -20,7 +20,7 @@ func TestGetDefaultMiddleWareWithMultipleOptions(t *testing.T) {
 			return true
 		},
 	}
-	compressionOptions := NewCompressionOptions(false)
+	compressionOptions := NewCompressionOptionsReference(false)
 	parametersNameDecodingOptions := ParametersNameDecodingOptions{
 		Enable:             true,
 		ParametersToDecode: []byte{'-', '.', '~', '$'},
@@ -36,7 +36,7 @@ func TestGetDefaultMiddleWareWithMultipleOptions(t *testing.T) {
 	}
 	options, err := GetDefaultMiddlewaresWithOptions(&retryOptions,
 		&redirectHandlerOptions,
-		&compressionOptions,
+		compressionOptions,
 		&parametersNameDecodingOptions,
 		&userAgentHandlerOptions,
 		&headersInspectionOptions,
@@ -67,19 +67,28 @@ func TestGetDefaultMiddleWareWithInvalidOption(t *testing.T) {
 }
 
 func TestGetDefaultMiddleWareWithOptions(t *testing.T) {
+	compression := NewCompressionOptionsReference(false)
+	options, err := GetDefaultMiddlewaresWithOptions(compression)
+	verifyMiddlewareWithDisabledCompression(t, options, err)
+}
+
+func TestGetDefaultMiddleWareWithOptionsDeprecated(t *testing.T) {
 	compression := NewCompressionOptions(false)
-	options, err := GetDefaultMiddlewaresWithOptions(&compression)
+	options, err := GetDefaultMiddlewaresWithOptions(compression)
+	verifyMiddlewareWithDisabledCompression(t, options, err)
+}
+
+func verifyMiddlewareWithDisabledCompression(t *testing.T, options []Middleware, err error) {
 	if err != nil {
 		t.Errorf(err.Error())
 	}
 	if len(options) != 6 {
 		t.Errorf("expected 6 middleware, got %v", len(options))
 	}
-
 	for _, element := range options {
 		switch v := element.(type) {
 		case *CompressionHandler:
-			assert.Equal(t, v.options.ShouldCompress(), compression.ShouldCompress())
+			assert.Equal(t, v.options.ShouldCompress(), false)
 		}
 	}
 }


### PR DESCRIPTION
I'm attempting to fix https://github.com/microsoft/kiota-http-go/issues/198 . It seems the reason is that in go, if an interface method has a non-pointer receiver, both `Foo` and `*Foo` types implement the interface, but if an interface method has a pointer receiver, only `*Foo` implements the interface. (See comments in the code).

I think this can be solved in two ways:

1. Add the `CompressionOptions` case into the switch statement, or
2. Change the receiver to a pointer receiver so it's consistent with the other `RequestOption` impls.

WDYT? Does the second option introduce any substantial breaking changes that would necessitate option 1?
